### PR TITLE
feat(init): Add initial setup for Stable Diffusion 3 on Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# Custom
+/sd3-cache/
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.bmp
+*.tiff
+*.webp
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# sd3-on-apple-silicon
-Run Stable Diffusion on Apple Silicon
+# Stable Diffusion 3 on Apple Silicon (MPS)
+
+This code allows you to run Stable Diffusion 3 on Apple Silicon devices using the MPS backend.
+
+## Prerequisites
+
+- Python 3.11
+- Conda
+- Hugging Face API token (optional)
+
+## Setup
+
+1. Create a new Conda environment:
+
+```bash
+conda create -n sd3 python=3.11 -y
+conda activate sd3
+```
+
+2. Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Set your Hugging Face API token (if required):
+
+```bash
+export HF_API_TOKEN=your_token_here
+```
+
+You can add this line to your `.zshrc` file to make it persistent.
+
+## Usage
+
+1. Save the provided code as `sd3-on-mps.py`.
+
+2. Run the script:
+
+```bash
+python sd3-on-mps.py
+```
+
+3. The generated image will be saved as `sd3-output-mps.png` in the same directory.
+
+## Notes
+
+- The code automatically detects the available device (MPS, CUDA, or CPU) and uses the best one.
+- If your system has less than 64 GB of RAM, the code enables attention slicing to reduce memory usage.
+- The model cache is set to `./sd3-cache` to avoid downloading the model repeatedly.
+- The image generation process may take some time depending on your hardware.
+
+That's it! You can now generate images using Stable Diffusion 3 on your Apple Silicon device.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+torch>=2.0.0
+diffusers
+transformers
+huggingface-hub
+protobuf
+sentencepiece
+accelerate
+psutil

--- a/sd3-on-mps.py
+++ b/sd3-on-mps.py
@@ -1,0 +1,49 @@
+import os
+import time
+import torch
+import psutil
+from diffusers import StableDiffusion3Pipeline
+
+SD3_MODEL_CACHE = "./sd3-cache"
+
+pipe = StableDiffusion3Pipeline.from_pretrained(
+    "stabilityai/stable-diffusion-3-medium-diffusers",
+    torch_dtype=torch.float16,
+    cache_dir=SD3_MODEL_CACHE,
+)
+
+# Check available system RAM and enable attention slicing if less than 64 GB
+if (available_ram := psutil.virtual_memory().available / (1024**3)) < 64:
+    pipe.enable_attention_slicing()
+
+# Automatically infer the device and prioritize "mps" if available
+device = (
+    "mps"
+    if torch.backends.mps.is_available()
+    else "cuda" if torch.cuda.is_available() else "cpu"
+)
+pipe = pipe.to(device)
+print(f"Pipeline moved to device: {pipe.device}")
+
+generator = torch.Generator(device=device).manual_seed(seed := 42)
+
+start_time = time.time()
+with torch.device(device):
+    print(f"Current device: {torch.device(device)}")
+    image = pipe(
+        prompt=(prompt := "A cat holding a sign that says hello world"),
+        height=(height := 512),
+        width=(width := 512),
+        num_inference_steps=28,
+        guidance_scale=7.0,
+        num_images_per_prompt=1,
+        generator=generator,
+        output_type="pil",
+        return_dict=True,
+        callback_on_step_end_tensor_inputs=["latents"],
+    ).images[0]
+end_time = time.time()
+print(f"Image generated successfully in {end_time - start_time:.2f} seconds.")
+
+if image and (image_path := "sd3-output-mps.png"):
+    image.save(image_path)


### PR DESCRIPTION
Adding the initial code to run Stable Diffusion 3 on Apple Silicon devices using the MPS backend. The code is simple to set up and run:

1. Create a new conda environment with Python 3.11
2. Install the required packages with pip
3. Run the Python script to generate an image

The code automatically detects the best available device (MPS, CUDA, CPU) and enables memory-saving features if needed. It saves the generated image as "sd3-output-mps.png" in the same directory.